### PR TITLE
Fix typo

### DIFF
--- a/src/ch10-02-traits.md
+++ b/src/ch10-02-traits.md
@@ -176,7 +176,7 @@ println!("1 new tweet: {}", tweet.summarize());
 
 知道了如何定义 trait 和在类型上实现这些 trait 之后，我们可以探索一下如何使用 trait 来接受多种不同类型的参数。
 
-例如在示例 10-13 中为 `NewsArticle` 和 `Tweet` 类型实现了 `Summary` trait。我们可以定义一个函数 `notify` 来调用其参数 `item` 上的 `summarize` 方法，该参数为一些实现了 `Summary` trait 的方法。为此可以使用 ‘`impl Trait`’ 语法，像这样：
+例如在示例 10-13 中为 `NewsArticle` 和 `Tweet` 类型实现了 `Summary` trait。我们可以定义一个函数 `notify` 来调用其参数 `item` 上的 `summarize` 方法，该参数是实现了 `Summary` trait 的某种类型。为此可以使用 `impl Trait` 语法，像这样：
 
 ```rust,ignore
 pub fn notify(item: impl Summary) {


### PR DESCRIPTION
原文（We can define a `notify` function that calls the `summarize` method on its `item` parameter, which is of some type that implements the `Summary` trait. ）。
其中（some type），旧的翻译（一些...方法）不符，应当译为（某种类型）。