### PR TITLE
纠正链接名"The Nomicon"为"The Rustonomicon"

### DIFF
--- a/src/ch15-06-reference-cycles.md
+++ b/src/ch15-06-reference-cycles.md
@@ -342,6 +342,6 @@ fn main() {
 
 如果本章内容引起了你的兴趣并希望现在就实现你自己的智能指针的话，请阅读 [“The Nomicon”] 来获取更多有用的信息。
 
-[“The Nomicon”]: https://doc.rust-lang.org/stable/nomicon/
+[“The Rustonomicon”]: https://doc.rust-lang.org/stable/nomicon/
 
 接下来，让我们谈谈 Rust 的并发。届时甚至还会学习到一些新的对并发有帮助的智能指针。


### PR DESCRIPTION
进入链接看到的名称为The Rustonomicon.