### PR TITLE
关于一处翻译问题

### DIFF
--- a/src/ch04-02-references-and-borrowing.md
+++ b/src/ch04-02-references-and-borrowing.md
@@ -141,7 +141,7 @@ error[E0499]: cannot borrow `s` as mutable more than once at a time
   |                        -- first borrow later used here
 ```
 
-这个限制允许可变性，不过是以一种受限制的方式允许。新 Rustacean 们经常与此作斗争，因为大部分语言中变量任何时候都是可变的。
+这个限制允许可变性，不过是以一种受限制的方式允许。新 Rustacean 们经常难以适应这一点，因为大部分语言中变量任何时候都是可变的。
 
 这个限制的好处是 Rust 可以在编译时就避免数据竞争。**数据竞争**（*data race*）类似于竞态条件，它可由这三个行为造成：
 


### PR DESCRIPTION
在ch04-02引用与借用中，有一处

> 这个限制允许可变性，不过是以一种受限制的方式允许。新 Rustacean 们经常与此作斗争，因为大部分语言中变量任何时候都是可变的。

英文原文为

> This restriction allows for mutation but in a very controlled fashion. It’s something that new Rustaceans struggle with, because most languages let you mutate whenever you’d like.

是的，struggle with的确可以被翻译为与...做斗争，但我认为在此处这么翻译不妥。易被误解为“新 Rustacean 们正在和语言标准对抗” or “新 Rustacean 们不认同这个特性”。 但实际上此处的意思应该是 “新 Rustacean 们对这个特性感到很难适应”。 因此希望修改。
