### PR TITLE
修改对照源码仓库地址

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@
 
 PS:
 
-* 对照源码位置：[https://github.com/rust-lang/book/tree/master/src][source]
+* 对照源码位置：[https://github.com/rust-lang/book/tree/main/src][source]
 * 每章翻译开头都带有官方链接和 commit hash，若发现与官方不一致，欢迎 Issue 或 PR :)
 
-[source]: https://github.com/rust-lang/book/tree/master/src
+[source]: https://github.com/rust-lang/book/tree/main/src
 
 ## 静态页面构建与文档撰写
 


### PR DESCRIPTION
官方源码仓库已经将master分支改成main分支了，所以官方源码地址更新为https://github.com/rust-lang/book/tree/main/src