### PR TITLE
更新示例 16-11的代码

### DIFF
--- a/src/ch16-02-message-passing.md
+++ b/src/ch16-02-message-passing.md
@@ -200,7 +200,7 @@ Got: thread
 
 let (tx, rx) = mpsc::channel();
 
-let tx1 = mpsc::Sender::clone(&tx);
+let tx1 = tx.clone();
 thread::spawn(move || {
     let vals = vec![
         String::from("hi"),


### PR DESCRIPTION
`clone()`为Sender的方法而非关联函数，所以用`tx.clone()`取代`mpsc::Sender::clone(&tx)`。经过验证官方仓库中已经修正，参考[链接](https://github.com/rust-lang/book/blob/main/listings/ch16-fearless-concurrency/listing-16-11/src/main.rs)。