### PR TITLE
更新原文链接

### DIFF
--- a/src/appendix-00.md
+++ b/src/appendix-00.md
@@ -1,6 +1,6 @@
 # 附录
 
-> [appendix-00.md](https://github.com/rust-lang/book/blob/master/src/appendix-00.md)
+> [appendix-00.md](https://github.com/rust-lang/book/blob/main/src/appendix-00.md)
 > <br>
 > commit 1fedfc4b96c2017f64ecfcf41a0a07e2e815f24f
 

--- a/src/appendix-01-keywords.md
+++ b/src/appendix-01-keywords.md
@@ -1,6 +1,6 @@
 ## 附录 A：关键字
 
-> [appendix-01-keywords.md](https://raw.githubusercontent.com/rust-lang/book/master/src/appendix-01-keywords.md)
+> [appendix-01-keywords.md](https://github.com/rust-lang/book/blob/main/src/appendix-01-keywords.md)
 > <br>
 > commit 27dd97a785794709aa87c51ab697cded41e8163a
 

--- a/src/appendix-02-operators.md
+++ b/src/appendix-02-operators.md
@@ -1,6 +1,6 @@
 ## 附录 B：运算符与符号
 
-> [appendix-02-operators.md](https://github.com/rust-lang/book/blob/master/src/appendix-02-operators.md)
+> [appendix-02-operators.md](https://github.com/rust-lang/book/blob/main/src/appendix-02-operators.md)
 > <br />
 > commit 426f3e4ec17e539ae9905ba559411169d303a031
 

--- a/src/appendix-03-derivable-traits.md
+++ b/src/appendix-03-derivable-traits.md
@@ -1,6 +1,6 @@
 ## 附录 C：可派生的 trait
 
-> [appendix-03-derivable-traits.md](https://github.com/rust-lang/book/blob/master/src/appendix-03-derivable-traits.md)
+> [appendix-03-derivable-traits.md](https://github.com/rust-lang/book/blob/main/src/appendix-03-derivable-traits.md)
 > <br />
 > commit 426f3e4ec17e539ae9905ba559411169d303a031
 

--- a/src/appendix-04-useful-development-tools.md
+++ b/src/appendix-04-useful-development-tools.md
@@ -1,6 +1,6 @@
 ## 附录 D：实用开发工具
 
-> [appendix-04-useful-development-tools.md](https://github.com/rust-lang/book/blob/master/src/appendix-04-useful-development-tools.md)
+> [appendix-04-useful-development-tools.md](https://github.com/rust-lang/book/blob/main/src/appendix-04-useful-development-tools.md)
 > <br />
 > commit 70a82519e48b8a61f98cabb8ff443d1b21962fea
 

--- a/src/appendix-05-editions.md
+++ b/src/appendix-05-editions.md
@@ -1,6 +1,6 @@
 ## 附录 E：版本
 
-> [appendix-05-editions.md](https://github.com/rust-lang/book/blob/master/src/appendix-05-editions.md)
+> [appendix-05-editions.md](https://github.com/rust-lang/book/blob/main/src/appendix-05-editions.md)
 > <br />
 > commit 70a82519e48b8a61f98cabb8ff443d1b21962fea
 

--- a/src/appendix-06-translation.md
+++ b/src/appendix-06-translation.md
@@ -1,6 +1,6 @@
 ## 附录 F：本书译本
 
-> [appendix-06-translation.md](https://github.com/rust-lang/book/blob/master/src/appendix-06-translation.md)
+> [appendix-06-translation.md](https://github.com/rust-lang/book/blob/main/src/appendix-06-translation.md)
 > <br />
 > commit 72900e05f04ae60e06c2665567771bdd8befa89c
 

--- a/src/appendix-07-nightly-rust.md
+++ b/src/appendix-07-nightly-rust.md
@@ -1,6 +1,6 @@
 ## 附录 G：Rust 是如何开发的与 “Nightly Rust”
 
-> [appendix-07-nightly-rust.md](https://github.com/rust-lang/book/blob/master/src/appendix-07-nightly-rust.md)
+> [appendix-07-nightly-rust.md](https://github.com/rust-lang/book/blob/main/src/appendix-07-nightly-rust.md)
 > <br />
 > commit 70a82519e48b8a61f98cabb8ff443d1b21962fea
 

--- a/src/ch00-00-introduction.md
+++ b/src/ch00-00-introduction.md
@@ -1,6 +1,6 @@
 # 介绍
 
-> [ch00-00-introduction.md](https://github.com/rust-lang/book/blob/master/src/ch00-00-introduction.md)
+> [ch00-00-introduction.md](https://github.com/rust-lang/book/blob/main/src/ch00-00-introduction.md)
 > <br>
 > commit 0aa307c7d79d2cbf83cdf5d47780b2904e9cb03f
 

--- a/src/ch01-00-getting-started.md
+++ b/src/ch01-00-getting-started.md
@@ -1,6 +1,6 @@
 # 入门指南
 
-> [ch01-00-getting-started.md](https://github.com/rust-lang/book/blob/master/src/ch01-00-getting-started.md)
+> [ch01-00-getting-started.md](https://github.com/rust-lang/book/blob/main/src/ch01-00-getting-started.md)
 > <br>
 > commit 1fedfc4b96c2017f64ecfcf41a0a07e2e815f24f
 

--- a/src/ch01-01-installation.md
+++ b/src/ch01-01-installation.md
@@ -1,6 +1,6 @@
 ## 安装
 
-> [ch01-01-installation.md](https://github.com/rust-lang/book/blob/master/src/ch01-01-installation.md) <br>
+> [ch01-01-installation.md](https://github.com/rust-lang/book/blob/main/src/ch01-01-installation.md) <br>
 > commit bad683bb7dcd06ef7f5f83bad3a25b1706b7b230
 
 第一步是安装 Rust。我们会通过 `rustup` 下载 Rust，这是一个管理 Rust 版本和相关工具的命令行工具。下载时需要联网。

--- a/src/ch01-02-hello-world.md
+++ b/src/ch01-02-hello-world.md
@@ -1,6 +1,6 @@
 ## Hello, World!
 
-> [ch01-02-hello-world.md](https://github.com/rust-lang/book/blob/master/src/ch01-02-hello-world.md)
+> [ch01-02-hello-world.md](https://github.com/rust-lang/book/blob/main/src/ch01-02-hello-world.md)
 > <br>
 > commit f63a103270ec8416899675a9cdb1c5cf6d77a498
 

--- a/src/ch01-03-hello-cargo.md
+++ b/src/ch01-03-hello-cargo.md
@@ -1,6 +1,6 @@
 ## Hello, Cargo!
 
-> [ch01-03-hello-cargo.md](https://github.com/rust-lang/book/blob/master/src/ch01-03-hello-cargo.md)
+> [ch01-03-hello-cargo.md](https://github.com/rust-lang/book/blob/main/src/ch01-03-hello-cargo.md)
 > <br>
 > commit f63a103270ec8416899675a9cdb1c5cf6d77a498
 

--- a/src/ch02-00-guessing-game-tutorial.md
+++ b/src/ch02-00-guessing-game-tutorial.md
@@ -1,6 +1,6 @@
 # 编写 猜猜看 游戏
 
-> [ch02-00-guessing-game-tutorial.md](https://github.com/rust-lang/book/blob/master/src/ch02-00-guessing-game-tutorial.md)
+> [ch02-00-guessing-game-tutorial.md](https://github.com/rust-lang/book/blob/main/src/ch02-00-guessing-game-tutorial.md)
 > <br>
 > commit c427a676393d001edc82f1a54a3b8026abcf9690
 

--- a/src/ch03-00-common-programming-concepts.md
+++ b/src/ch03-00-common-programming-concepts.md
@@ -1,6 +1,6 @@
 # 常见编程概念
 
-> [ch03-00-common-programming-concepts.md](https://github.com/rust-lang/book/blob/master/src/ch03-00-common-programming-concepts.md)
+> [ch03-00-common-programming-concepts.md](https://github.com/rust-lang/book/blob/main/src/ch03-00-common-programming-concepts.md)
 > <br>
 > commit 1f49356cb21cbc27bc5359bfe655d26757d4b137
 

--- a/src/ch03-01-variables-and-mutability.md
+++ b/src/ch03-01-variables-and-mutability.md
@@ -1,6 +1,6 @@
 ## 变量和可变性
 
-> [ch03-01-variables-and-mutability.md](https://github.com/rust-lang/book/blob/master/src/ch03-01-variables-and-mutability.md)
+> [ch03-01-variables-and-mutability.md](https://github.com/rust-lang/book/blob/main/src/ch03-01-variables-and-mutability.md)
 > <br>
 > commit d69b1058c660abfe1d274c58d39c06ebd5c96c47
 

--- a/src/ch03-02-data-types.md
+++ b/src/ch03-02-data-types.md
@@ -1,6 +1,6 @@
 ## 数据类型
 
-> [ch03-02-data-types.md](https://github.com/rust-lang/book/blob/master/src/ch03-02-data-types.md)
+> [ch03-02-data-types.md](https://github.com/rust-lang/book/blob/main/src/ch03-02-data-types.md)
 > <br>
 > commit 6598d3abac05ed1d0c45db92466ea49346d05e40
 

--- a/src/ch03-03-how-functions-work.md
+++ b/src/ch03-03-how-functions-work.md
@@ -1,6 +1,6 @@
 ## 函数
 
-> [ch03-03-how-functions-work.md](https://github.com/rust-lang/book/blob/master/src/ch03-03-how-functions-work.md)
+> [ch03-03-how-functions-work.md](https://github.com/rust-lang/book/blob/main/src/ch03-03-how-functions-work.md)
 > <br>
 > commit 669a909a199bc20b913703c6618741d8b6ce1552
 

--- a/src/ch03-04-comments.md
+++ b/src/ch03-04-comments.md
@@ -1,6 +1,6 @@
 ## 注释
 
-> [ch03-04-comments.md](https://github.com/rust-lang/book/blob/master/src/ch03-04-comments.md)
+> [ch03-04-comments.md](https://github.com/rust-lang/book/blob/main/src/ch03-04-comments.md)
 > <br>
 > commit 75a77762ea2d2ab7fa1e9ef733907ed727c85651
 

--- a/src/ch03-05-control-flow.md
+++ b/src/ch03-05-control-flow.md
@@ -1,6 +1,6 @@
 ## 控制流
 
-> [ch03-05-control-flow.md](https://github.com/rust-lang/book/blob/master/src/ch03-05-control-flow.md)
+> [ch03-05-control-flow.md](https://github.com/rust-lang/book/blob/main/src/ch03-05-control-flow.md)
 > <br>
 > commit af34ac954a6bd7fc4a8bbcc5c9685e23c5af87da
 

--- a/src/ch04-00-understanding-ownership.md
+++ b/src/ch04-00-understanding-ownership.md
@@ -1,6 +1,6 @@
 # 认识所有权
 
-> [ch04-00-understanding-ownership.md](https://github.com/rust-lang/book/blob/master/src/ch04-00-understanding-ownership.md)
+> [ch04-00-understanding-ownership.md](https://github.com/rust-lang/book/blob/main/src/ch04-00-understanding-ownership.md)
 > <br>
 > commit 1fedfc4b96c2017f64ecfcf41a0a07e2e815f24f
 

--- a/src/ch04-01-what-is-ownership.md
+++ b/src/ch04-01-what-is-ownership.md
@@ -1,6 +1,6 @@
 ## 什么是所有权？
 
-> [ch04-01-what-is-ownership.md](https://github.com/rust-lang/book/blob/master/src/ch04-01-what-is-ownership.md)
+> [ch04-01-what-is-ownership.md](https://github.com/rust-lang/book/blob/main/src/ch04-01-what-is-ownership.md)
 > <br>
 > commit e81710c276b3839e8ec54d5f12aec4f9de88924b
 

--- a/src/ch04-02-references-and-borrowing.md
+++ b/src/ch04-02-references-and-borrowing.md
@@ -1,6 +1,6 @@
 ## 引用与借用
 
-> [ch04-02-references-and-borrowing.md](https://github.com/rust-lang/book/blob/master/src/ch04-02-references-and-borrowing.md)
+> [ch04-02-references-and-borrowing.md](https://github.com/rust-lang/book/blob/main/src/ch04-02-references-and-borrowing.md)
 > <br>
 > commit 4f19894e592cd24ac1476f1310dcf437ae83d4ba
 

--- a/src/ch04-03-slices.md
+++ b/src/ch04-03-slices.md
@@ -1,6 +1,6 @@
 ## Slice 类型
 
-> [ch04-03-slices.md](https://github.com/rust-lang/book/blob/master/src/ch04-03-slices.md)
+> [ch04-03-slices.md](https://github.com/rust-lang/book/blob/main/src/ch04-03-slices.md)
 > <br>
 > commit 9fcebe6e1b0b5e842285015dbf093f97cd5b3803
 

--- a/src/ch05-00-structs.md
+++ b/src/ch05-00-structs.md
@@ -1,6 +1,6 @@
 # 使用结构体组织相关联的数据
 
-> [ch05-00-structs.md](https://github.com/rust-lang/book/blob/master/src/ch05-00-structs.md)
+> [ch05-00-structs.md](https://github.com/rust-lang/book/blob/main/src/ch05-00-structs.md)
 > <br>
 > commit 1fedfc4b96c2017f64ecfcf41a0a07e2e815f24f
 

--- a/src/ch05-01-defining-structs.md
+++ b/src/ch05-01-defining-structs.md
@@ -1,6 +1,6 @@
 ## 定义并实例化结构体
 
-> [ch05-01-defining-structs.md](https://github.com/rust-lang/book/blob/master/src/ch05-01-defining-structs.md)
+> [ch05-01-defining-structs.md](https://github.com/rust-lang/book/blob/main/src/ch05-01-defining-structs.md)
 > <br>
 > commit f617d58c1a88dd2912739a041fd4725d127bf9fb
 

--- a/src/ch05-02-example-structs.md
+++ b/src/ch05-02-example-structs.md
@@ -1,6 +1,6 @@
 ## 一个使用结构体的示例程序
 
-> [ch05-02-example-structs.md](https://github.com/rust-lang/book/blob/master/src/ch05-02-example-structs.md)
+> [ch05-02-example-structs.md](https://github.com/rust-lang/book/blob/main/src/ch05-02-example-structs.md)
 > <br>
 > commit 9cb1d20394f047855a57228dc4cbbabd0a9b395a
 

--- a/src/ch05-03-method-syntax.md
+++ b/src/ch05-03-method-syntax.md
@@ -1,6 +1,6 @@
 ## 方法语法
 
-> [ch05-03-method-syntax.md](https://github.com/rust-lang/book/blob/master/src/ch05-03-method-syntax.md)
+> [ch05-03-method-syntax.md](https://github.com/rust-lang/book/blob/main/src/ch05-03-method-syntax.md)
 > <br>
 > commit a86c1d315789b3ca13b20d50ad5005c62bdd9e37
 

--- a/src/ch06-00-enums.md
+++ b/src/ch06-00-enums.md
@@ -1,6 +1,6 @@
 # 枚举和模式匹配
 
-> [ch06-00-enums.md](https://github.com/rust-lang/book/blob/master/src/ch06-00-enums.md)
+> [ch06-00-enums.md](https://github.com/rust-lang/book/blob/main/src/ch06-00-enums.md)
 > <br>
 > commit a5a03d8f61a5b2c2111b21031a3f526ef60844dd
 

--- a/src/ch06-01-defining-an-enum.md
+++ b/src/ch06-01-defining-an-enum.md
@@ -1,6 +1,6 @@
 ## 定义枚举
 
-> [ch06-01-defining-an-enum.md](https://github.com/rust-lang/book/blob/master/src/ch06-01-defining-an-enum.md)
+> [ch06-01-defining-an-enum.md](https://github.com/rust-lang/book/blob/main/src/ch06-01-defining-an-enum.md)
 > <br>
 > commit a5a03d8f61a5b2c2111b21031a3f526ef60844dd
 

--- a/src/ch06-02-match.md
+++ b/src/ch06-02-match.md
@@ -1,6 +1,6 @@
 ## `match` 控制流运算符
 
-> [ch06-02-match.md](https://github.com/rust-lang/book/blob/master/src/ch06-02-match.md)
+> [ch06-02-match.md](https://github.com/rust-lang/book/blob/main/src/ch06-02-match.md)
 > <br>
 > commit b374e75f1d7b743c84a6bb1ef72579a6588bcb8a
 

--- a/src/ch06-03-if-let.md
+++ b/src/ch06-03-if-let.md
@@ -1,6 +1,6 @@
 ## `if let` 简单控制流
 
-> [ch06-03-if-let.md](https://github.com/rust-lang/book/blob/master/src/ch06-03-if-let.md)
+> [ch06-03-if-let.md](https://github.com/rust-lang/book/blob/main/src/ch06-03-if-let.md)
 > <br>
 > commit a86c1d315789b3ca13b20d50ad5005c62bdd9e37
 

--- a/src/ch07-00-managing-growing-projects-with-packages-crates-and-modules.md
+++ b/src/ch07-00-managing-growing-projects-with-packages-crates-and-modules.md
@@ -1,6 +1,6 @@
 # 使用包、Crate和模块管理不断增长的项目
 
-> [ch07-00-managing-growing-projects-with-packages-crates-and-modules.md](https://github.com/rust-lang/book/blob/master/src/ch07-00-managing-growing-projects-with-packages-crates-and-modules.md)
+> [ch07-00-managing-growing-projects-with-packages-crates-and-modules.md](https://github.com/rust-lang/book/blob/main/src/ch07-00-managing-growing-projects-with-packages-crates-and-modules.md)
 > <br>
 > commit 879fef2345bf32751a83a9e779e0cb84e79b6d3d
 

--- a/src/ch07-01-packages-and-crates.md
+++ b/src/ch07-01-packages-and-crates.md
@@ -1,6 +1,6 @@
 ## 包和 crate
 
-> [ch07-01-packages-and-crates.md](https://github.com/rust-lang/book/blob/master/src/ch07-01-packages-and-crates.md)
+> [ch07-01-packages-and-crates.md](https://github.com/rust-lang/book/blob/main/src/ch07-01-packages-and-crates.md)
 > <br>
 > commit 879fef2345bf32751a83a9e779e0cb84e79b6d3d
 

--- a/src/ch07-02-defining-modules-to-control-scope-and-privacy.md
+++ b/src/ch07-02-defining-modules-to-control-scope-and-privacy.md
@@ -1,6 +1,6 @@
 ## 定义模块来控制作用域与私有性
 
-> [ch07-02-defining-modules-to-control-scope-and-privacy.md](https://github.com/rust-lang/book/blob/master/src/ch07-02-defining-modules-to-control-scope-and-privacy.md)
+> [ch07-02-defining-modules-to-control-scope-and-privacy.md](https://github.com/rust-lang/book/blob/main/src/ch07-02-defining-modules-to-control-scope-and-privacy.md)
 > <br>
 > commit 34b089627cca09a73ce92a052222304bff0056e3
 

--- a/src/ch07-03-paths-for-referring-to-an-item-in-the-module-tree.md
+++ b/src/ch07-03-paths-for-referring-to-an-item-in-the-module-tree.md
@@ -1,6 +1,6 @@
 ## 路径用于引用模块树中的项
 
-> [ch07-03-paths-for-referring-to-an-item-in-the-module-tree.md](https://github.com/rust-lang/book/blob/master/src/ch07-03-paths-for-referring-to-an-item-in-the-module-tree.md)
+> [ch07-03-paths-for-referring-to-an-item-in-the-module-tree.md](https://github.com/rust-lang/book/blob/main/src/ch07-03-paths-for-referring-to-an-item-in-the-module-tree.md)
 > <br>
 > commit cc6a1ef2614aa94003566027b285b249ccf961fa
 

--- a/src/ch07-04-bringing-paths-into-scope-with-the-use-keyword.md
+++ b/src/ch07-04-bringing-paths-into-scope-with-the-use-keyword.md
@@ -1,6 +1,6 @@
 ## 使用 `use` 关键字将名称引入作用域
 
-> [ch07-04-bringing-paths-into-scope-with-the-use-keyword.md](https://github.com/rust-lang/book/blob/master/src/ch07-04-bringing-paths-into-scope-with-the-use-keyword.md)
+> [ch07-04-bringing-paths-into-scope-with-the-use-keyword.md](https://github.com/rust-lang/book/blob/main/src/ch07-04-bringing-paths-into-scope-with-the-use-keyword.md)
 > <br>
 > commit 6d3e76820418f2d2bb203233c61d90390b5690f1
 

--- a/src/ch07-05-separating-modules-into-different-files.md
+++ b/src/ch07-05-separating-modules-into-different-files.md
@@ -1,6 +1,6 @@
 ## 将模块分割进不同文件
 
-> [ch07-05-separating-modules-into-different-files.md](https://github.com/rust-lang/book/blob/master/src/ch07-05-separating-modules-into-different-files.md)
+> [ch07-05-separating-modules-into-different-files.md](https://github.com/rust-lang/book/blob/main/src/ch07-05-separating-modules-into-different-files.md)
 > <br>
 > commit a5a5bf9d6ea5763a9110f727911a21da854b1d90
 

--- a/src/ch08-00-common-collections.md
+++ b/src/ch08-00-common-collections.md
@@ -1,6 +1,6 @@
 # 常见集合
 
-> [ch08-00-common-collections.md](https://github.com/rust-lang/book/blob/master/src/ch08-00-common-collections.md)
+> [ch08-00-common-collections.md](https://github.com/rust-lang/book/blob/main/src/ch08-00-common-collections.md)
 > <br>
 > commit 820ac357f6cf0e866e5a8e7a9c57dd3e17e9f8ca
 

--- a/src/ch08-01-vectors.md
+++ b/src/ch08-01-vectors.md
@@ -1,6 +1,6 @@
 ## vector 用来储存一系列的值
 
-> [ch08-01-vectors.md](https://github.com/rust-lang/book/blob/master/src/ch08-01-vectors.md)
+> [ch08-01-vectors.md](https://github.com/rust-lang/book/blob/main/src/ch08-01-vectors.md)
 > <br>
 > commit 76df60bccead5f3de96db23d97b69597cd8a2b82
 

--- a/src/ch08-02-strings.md
+++ b/src/ch08-02-strings.md
@@ -1,6 +1,6 @@
 ## 使用字符串存储 UTF-8 编码的文本
 
-> [ch08-02-strings.md](https://github.com/rust-lang/book/blob/master/src/ch08-02-strings.md)
+> [ch08-02-strings.md](https://github.com/rust-lang/book/blob/main/src/ch08-02-strings.md)
 > <br>
 > commit c084bdd9ee328e7e774df19882ccc139532e53d8
 

--- a/src/ch08-03-hash-maps.md
+++ b/src/ch08-03-hash-maps.md
@@ -1,6 +1,6 @@
 ## 哈希 map 储存键值对
 
-> [ch08-03-hash-maps.md](https://github.com/rust-lang/book/blob/master/src/ch08-03-hash-maps.md)
+> [ch08-03-hash-maps.md](https://github.com/rust-lang/book/blob/main/src/ch08-03-hash-maps.md)
 > <br>
 > commit 85b02530cc749565c26c05bf1b3a838334e9717f
 

--- a/src/ch09-00-error-handling.md
+++ b/src/ch09-00-error-handling.md
@@ -1,6 +1,6 @@
 # 错误处理
 
-> [ch09-00-error-handling.md](https://github.com/rust-lang/book/blob/master/src/ch09-00-error-handling.md)
+> [ch09-00-error-handling.md](https://github.com/rust-lang/book/blob/main/src/ch09-00-error-handling.md)
 > <br>
 > commit 1fedfc4b96c2017f64ecfcf41a0a07e2e815f24f
 

--- a/src/ch09-01-unrecoverable-errors-with-panic.md
+++ b/src/ch09-01-unrecoverable-errors-with-panic.md
@@ -1,6 +1,6 @@
 ## `panic!` 与不可恢复的错误
 
-> [ch09-01-unrecoverable-errors-with-panic.md](https://github.com/rust-lang/book/blob/master/src/ch09-01-unrecoverable-errors-with-panic.md)
+> [ch09-01-unrecoverable-errors-with-panic.md](https://github.com/rust-lang/book/blob/main/src/ch09-01-unrecoverable-errors-with-panic.md)
 > <br>
 > commit 426f3e4ec17e539ae9905ba559411169d303a031
 

--- a/src/ch09-02-recoverable-errors-with-result.md
+++ b/src/ch09-02-recoverable-errors-with-result.md
@@ -1,6 +1,6 @@
 ## `Result` 与可恢复的错误
 
-> [ch09-02-recoverable-errors-with-result.md](https://github.com/rust-lang/book/blob/master/src/ch09-02-recoverable-errors-with-result.md)
+> [ch09-02-recoverable-errors-with-result.md](https://github.com/rust-lang/book/blob/main/src/ch09-02-recoverable-errors-with-result.md)
 > <br>
 > commit aa339f78da31c330ede3f1b52b4bbfb62d7814cb
 

--- a/src/ch09-03-to-panic-or-not-to-panic.md
+++ b/src/ch09-03-to-panic-or-not-to-panic.md
@@ -1,6 +1,6 @@
 ## `panic!` 还是不 `panic!`
 
-> [ch09-03-to-panic-or-not-to-panic.md](https://github.com/rust-lang/book/blob/master/src/ch09-03-to-panic-or-not-to-panic.md)
+> [ch09-03-to-panic-or-not-to-panic.md](https://github.com/rust-lang/book/blob/main/src/ch09-03-to-panic-or-not-to-panic.md)
 > <br>
 > commit 76df60bccead5f3de96db23d97b69597cd8a2b82
 

--- a/src/ch10-00-generics.md
+++ b/src/ch10-00-generics.md
@@ -1,6 +1,6 @@
 # 泛型、trait 和生命周期
 
-> [ch10-00-generics.md](https://github.com/rust-lang/book/blob/master/src/ch10-00-generics.md)
+> [ch10-00-generics.md](https://github.com/rust-lang/book/blob/main/src/ch10-00-generics.md)
 > <br>
 > commit 48b057106646758f6453f42b7887f34b8c24caf6
 

--- a/src/ch10-01-syntax.md
+++ b/src/ch10-01-syntax.md
@@ -1,6 +1,6 @@
 ## 泛型数据类型
 
-> [ch10-01-syntax.md](https://github.com/rust-lang/book/blob/master/src/ch10-01-syntax.md)
+> [ch10-01-syntax.md](https://github.com/rust-lang/book/blob/main/src/ch10-01-syntax.md)
 > <br>
 > commit af34ac954a6bd7fc4a8bbcc5c9685e23c5af87da
 

--- a/src/ch10-02-traits.md
+++ b/src/ch10-02-traits.md
@@ -1,6 +1,6 @@
 ## trait：定义共享的行为
 
-> [ch10-02-traits.md](https://github.com/rust-lang/book/blob/master/src/ch10-02-traits.md)
+> [ch10-02-traits.md](https://github.com/rust-lang/book/blob/main/src/ch10-02-traits.md)
 > <br>
 > commit 34b403864ad9c5e27b00b7cc4a6893804ef5b989
 

--- a/src/ch10-03-lifetime-syntax.md
+++ b/src/ch10-03-lifetime-syntax.md
@@ -1,6 +1,6 @@
 ## 生命周期与引用有效性
 
-> [ch10-03-lifetime-syntax.md](https://github.com/rust-lang/book/blob/master/src/ch10-03-lifetime-syntax.md)
+> [ch10-03-lifetime-syntax.md](https://github.com/rust-lang/book/blob/main/src/ch10-03-lifetime-syntax.md)
 > <br>
 > commit 426f3e4ec17e539ae9905ba559411169d303a031
 

--- a/src/ch11-00-testing.md
+++ b/src/ch11-00-testing.md
@@ -1,6 +1,6 @@
 # 编写自动化测试
 
-> [ch11-00-testing.md](https://github.com/rust-lang/book/blob/master/src/ch11-00-testing.md)
+> [ch11-00-testing.md](https://github.com/rust-lang/book/blob/main/src/ch11-00-testing.md)
 > <br>
 > commit 1fedfc4b96c2017f64ecfcf41a0a07e2e815f24f
 

--- a/src/ch11-01-writing-tests.md
+++ b/src/ch11-01-writing-tests.md
@@ -1,6 +1,6 @@
 ## 如何编写测试
 
-> [ch11-01-writing-tests.md](https://github.com/rust-lang/book/blob/master/src/ch11-01-writing-tests.md)
+> [ch11-01-writing-tests.md](https://github.com/rust-lang/book/blob/main/src/ch11-01-writing-tests.md)
 > <br>
 > commit cc6a1ef2614aa94003566027b285b249ccf961fa
 

--- a/src/ch11-02-running-tests.md
+++ b/src/ch11-02-running-tests.md
@@ -1,6 +1,6 @@
 ## 控制测试如何运行
 
-> [ch11-02-running-tests.md](https://github.com/rust-lang/book/blob/master/src/ch11-02-running-tests.md)
+> [ch11-02-running-tests.md](https://github.com/rust-lang/book/blob/main/src/ch11-02-running-tests.md)
 > <br>
 > commit 42b802f26197f9a066e4a671d2b062af25972c13
 

--- a/src/ch11-03-test-organization.md
+++ b/src/ch11-03-test-organization.md
@@ -1,6 +1,6 @@
 ## 测试的组织结构
 
-> [ch11-03-test-organization.md](https://github.com/rust-lang/book/blob/master/src/ch11-03-test-organization.md)
+> [ch11-03-test-organization.md](https://github.com/rust-lang/book/blob/main/src/ch11-03-test-organization.md)
 > <br>
 > commit 4badf9a8574c12794795b05954baf5adc579fa90
 

--- a/src/ch12-00-an-io-project.md
+++ b/src/ch12-00-an-io-project.md
@@ -1,6 +1,6 @@
 # 一个 I/O 项目：构建一个命令行程序
 
-> [ch12-00-an-io-project.md](https://github.com/rust-lang/book/blob/master/src/ch12-00-an-io-project.md)
+> [ch12-00-an-io-project.md](https://github.com/rust-lang/book/blob/main/src/ch12-00-an-io-project.md)
 > <br>
 > commit db919bc6bb9071566e9c4f05053672133eaac33e
 

--- a/src/ch12-01-accepting-command-line-arguments.md
+++ b/src/ch12-01-accepting-command-line-arguments.md
@@ -1,6 +1,6 @@
 ### 接受命令行参数
 
-> [ch12-01-accepting-command-line-arguments.md](https://github.com/rust-lang/book/blob/master/src/ch12-01-accepting-command-line-arguments.md)
+> [ch12-01-accepting-command-line-arguments.md](https://github.com/rust-lang/book/blob/main/src/ch12-01-accepting-command-line-arguments.md)
 > <br>
 > commit c084bdd9ee328e7e774df19882ccc139532e53d8
 

--- a/src/ch12-02-reading-a-file.md
+++ b/src/ch12-02-reading-a-file.md
@@ -1,6 +1,6 @@
 ### 读取文件
 
-> [ch12-02-reading-a-file.md](https://github.com/rust-lang/book/blob/master/src/ch12-02-reading-a-file.md)
+> [ch12-02-reading-a-file.md](https://github.com/rust-lang/book/blob/main/src/ch12-02-reading-a-file.md)
 > <br>
 > commit 76df60bccead5f3de96db23d97b69597cd8a2b82
 

--- a/src/ch12-03-improving-error-handling-and-modularity.md
+++ b/src/ch12-03-improving-error-handling-and-modularity.md
@@ -1,6 +1,6 @@
 ## 重构改进模块性和错误处理
 
-> [ch12-03-improving-error-handling-and-modularity.md](https://github.com/rust-lang/book/blob/master/src/ch12-03-improving-error-handling-and-modularity.md)
+> [ch12-03-improving-error-handling-and-modularity.md](https://github.com/rust-lang/book/blob/main/src/ch12-03-improving-error-handling-and-modularity.md)
 > <br>
 > commit 426f3e4ec17e539ae9905ba559411169d303a031
 

--- a/src/ch12-04-testing-the-librarys-functionality.md
+++ b/src/ch12-04-testing-the-librarys-functionality.md
@@ -1,6 +1,6 @@
 ## 采用测试驱动开发完善库的功能
 
-> [ch12-04-testing-the-librarys-functionality.md](https://github.com/rust-lang/book/blob/master/src/ch12-04-testing-the-librarys-functionality.md)
+> [ch12-04-testing-the-librarys-functionality.md](https://github.com/rust-lang/book/blob/main/src/ch12-04-testing-the-librarys-functionality.md)
 > <br>
 > commit 0ca4b88f75f8579de87adc2ad36d340709f5ccad
 

--- a/src/ch12-05-working-with-environment-variables.md
+++ b/src/ch12-05-working-with-environment-variables.md
@@ -1,6 +1,6 @@
 ## 处理环境变量
 
-> [ch12-05-working-with-environment-variables.md](https://github.com/rust-lang/book/blob/master/src/ch12-05-working-with-environment-variables.md)
+> [ch12-05-working-with-environment-variables.md](https://github.com/rust-lang/book/blob/main/src/ch12-05-working-with-environment-variables.md)
 > <br>
 > commit f617d58c1a88dd2912739a041fd4725d127bf9fb
 

--- a/src/ch12-06-writing-to-stderr-instead-of-stdout.md
+++ b/src/ch12-06-writing-to-stderr-instead-of-stdout.md
@@ -1,6 +1,6 @@
 ## 将错误信息输出到标准错误而不是标准输出
 
-> [ch12-06-writing-to-stderr-instead-of-stdout.md](https://github.com/rust-lang/book/blob/master/src/ch12-06-writing-to-stderr-instead-of-stdout.md)
+> [ch12-06-writing-to-stderr-instead-of-stdout.md](https://github.com/rust-lang/book/blob/main/src/ch12-06-writing-to-stderr-instead-of-stdout.md)
 > <br>
 > commit 1fedfc4b96c2017f64ecfcf41a0a07e2e815f24f
 

--- a/src/ch13-00-functional-features.md
+++ b/src/ch13-00-functional-features.md
@@ -1,6 +1,6 @@
 # Rust 中的函数式语言功能：迭代器与闭包
 
-> [ch13-00-functional-features.md](https://github.com/rust-lang/book/blob/master/src/ch13-00-functional-features.md)
+> [ch13-00-functional-features.md](https://github.com/rust-lang/book/blob/main/src/ch13-00-functional-features.md)
 > <br>
 > commit 1fedfc4b96c2017f64ecfcf41a0a07e2e815f24f
 

--- a/src/ch13-01-closures.md
+++ b/src/ch13-01-closures.md
@@ -1,6 +1,6 @@
 ## 闭包：可以捕获环境的匿名函数
 
-> [ch13-01-closures.md](https://github.com/rust-lang/book/blob/master/src/ch13-01-closures.md)
+> [ch13-01-closures.md](https://github.com/rust-lang/book/blob/main/src/ch13-01-closures.md)
 > <br>
 > commit 26565efc3f62d9dacb7c2c6d0f5974360e459493
 

--- a/src/ch13-02-iterators.md
+++ b/src/ch13-02-iterators.md
@@ -1,6 +1,6 @@
 ## 使用迭代器处理元素序列
 
-> [ch13-02-iterators.md](https://github.com/rust-lang/book/blob/master/src/ch13-02-iterators.md)
+> [ch13-02-iterators.md](https://github.com/rust-lang/book/blob/main/src/ch13-02-iterators.md)
 > <br>
 > commit 8edf0457ab571b375b87357e1353ae0dd2127abe
 

--- a/src/ch13-03-improving-our-io-project.md
+++ b/src/ch13-03-improving-our-io-project.md
@@ -1,6 +1,6 @@
 ## 改进 I/O 项目
 
-> [ch13-03-improving-our-io-project.md](https://github.com/rust-lang/book/blob/master/src/ch13-03-improving-our-io-project.md)
+> [ch13-03-improving-our-io-project.md](https://github.com/rust-lang/book/blob/main/src/ch13-03-improving-our-io-project.md)
 > <br>
 > commit 6555fb6c805fbfe7d0961980991f8bca6918928f
 

--- a/src/ch13-04-performance.md
+++ b/src/ch13-04-performance.md
@@ -1,6 +1,6 @@
 ## 性能对比：循环 VS 迭代器
 
-> [ch13-04-performance.md](https://github.com/rust-lang/book/blob/master/src/ch13-04-performance.md)
+> [ch13-04-performance.md](https://github.com/rust-lang/book/blob/main/src/ch13-04-performance.md)
 > <br>
 > commit 1fedfc4b96c2017f64ecfcf41a0a07e2e815f24f
 

--- a/src/ch14-00-more-about-cargo.md
+++ b/src/ch14-00-more-about-cargo.md
@@ -1,6 +1,6 @@
 # 进一步认识 Cargo 和 Crates.io
 
-> [ch14-00-more-about-cargo.md](https://github.com/rust-lang/book/blob/master/src/ch14-00-more-about-cargo.md)
+> [ch14-00-more-about-cargo.md](https://github.com/rust-lang/book/blob/main/src/ch14-00-more-about-cargo.md)
 > <br>
 > commit c084bdd9ee328e7e774df19882ccc139532e53d8
 

--- a/src/ch14-01-release-profiles.md
+++ b/src/ch14-01-release-profiles.md
@@ -1,6 +1,6 @@
 ## 采用发布配置自定义构建
 
-> [ch14-01-release-profiles.md](https://github.com/rust-lang/book/blob/master/src/ch14-01-release-profiles.md)
+> [ch14-01-release-profiles.md](https://github.com/rust-lang/book/blob/main/src/ch14-01-release-profiles.md)
 > <br>
 > commit 0f10093ac5fbd57feb2352e08ee6d3efd66f887c
 

--- a/src/ch14-02-publishing-to-crates-io.md
+++ b/src/ch14-02-publishing-to-crates-io.md
@@ -1,6 +1,6 @@
 ## 将 crate 发布到 Crates.io
 
-> [ch14-02-publishing-to-crates-io.md](https://github.com/rust-lang/book/blob/master/src/ch14-02-publishing-to-crates-io.md) <br>
+> [ch14-02-publishing-to-crates-io.md](https://github.com/rust-lang/book/blob/main/src/ch14-02-publishing-to-crates-io.md) <br>
 > commit c084bdd9ee328e7e774df19882ccc139532e53d8
 
 我们曾经在项目中使用 [crates.io](https://crates.io)<!-- ignore --> 上的包作为依赖，不过你也可以通过发布自己的包来向它人分享代码。[crates.io](https://crates.io)<!-- ignore --> 用来分发包的源代码，所以它主要托管开源代码。

--- a/src/ch14-03-cargo-workspaces.md
+++ b/src/ch14-03-cargo-workspaces.md
@@ -1,6 +1,6 @@
 ## Cargo 工作空间
 
-> [ch14-03-cargo-workspaces.md](https://github.com/rust-lang/book/blob/master/src/ch14-03-cargo-workspaces.md)
+> [ch14-03-cargo-workspaces.md](https://github.com/rust-lang/book/blob/main/src/ch14-03-cargo-workspaces.md)
 > <br>
 > commit 6d3e76820418f2d2bb203233c61d90390b5690f1
 

--- a/src/ch14-04-installing-binaries.md
+++ b/src/ch14-04-installing-binaries.md
@@ -1,6 +1,6 @@
 ## 使用 `cargo install` 从 Crates.io 安装二进制文件
 
-> [ch14-04-installing-binaries.md](https://github.com/rust-lang/book/blob/master/src/ch14-04-installing-binaries.md)
+> [ch14-04-installing-binaries.md](https://github.com/rust-lang/book/blob/main/src/ch14-04-installing-binaries.md)
 > <br>
 > commit c084bdd9ee328e7e774df19882ccc139532e53d8
 

--- a/src/ch14-05-extending-cargo.md
+++ b/src/ch14-05-extending-cargo.md
@@ -1,6 +1,6 @@
 ## Cargo 自定义扩展命令
 
-> [ch14-05-extending-cargo.md](https://github.com/rust-lang/book/blob/master/src/ch14-05-extending-cargo.md)
+> [ch14-05-extending-cargo.md](https://github.com/rust-lang/book/blob/main/src/ch14-05-extending-cargo.md)
 > <br>
 > commit c084bdd9ee328e7e774df19882ccc139532e53d8
 

--- a/src/ch15-00-smart-pointers.md
+++ b/src/ch15-00-smart-pointers.md
@@ -1,6 +1,6 @@
 # 智能指针
 
-> [ch15-00-smart-pointers.md](https://github.com/rust-lang/book/blob/master/src/ch15-00-smart-pointers.md)
+> [ch15-00-smart-pointers.md](https://github.com/rust-lang/book/blob/main/src/ch15-00-smart-pointers.md)
 > <br>
 > commit 1fedfc4b96c2017f64ecfcf41a0a07e2e815f24f
 

--- a/src/ch15-01-box.md
+++ b/src/ch15-01-box.md
@@ -1,6 +1,6 @@
 ## 使用`Box <T>`指向堆上的数据
 
-> [ch15-01-box.md](https://github.com/rust-lang/book/blob/master/src/ch15-01-box.md) <br>
+> [ch15-01-box.md](https://github.com/rust-lang/book/blob/main/src/ch15-01-box.md) <br>
 > commit a203290c640a378453261948b3fee4c4c6eb3d0f
 
 最简单直接的智能指针是 _box_，其类型是 `Box<T>`。 box 允许你将一个值放在堆上而不是栈上。留在栈上的则是指向堆数据的指针。如果你想回顾一下栈与堆的区别请参考第四章。

--- a/src/ch15-02-deref.md
+++ b/src/ch15-02-deref.md
@@ -1,6 +1,6 @@
 ## 通过 `Deref` trait 将智能指针当作常规引用处理
 
-> [ch15-02-deref.md](https://github.com/rust-lang/book/blob/master/src/ch15-02-deref.md) <br>
+> [ch15-02-deref.md](https://github.com/rust-lang/book/blob/main/src/ch15-02-deref.md) <br>
 > commit 44f1b71c117b0dcec7805eced0b95405167092f6
 
 实现 `Deref` trait 允许我们重载 **解引用运算符**（_dereference operator_）`*`（与乘法运算符或通配符相区别）。通过这种方式实现 `Deref` trait 的智能指针可以被当作常规引用来对待，可以编写操作引用的代码并用于智能指针。

--- a/src/ch15-03-drop.md
+++ b/src/ch15-03-drop.md
@@ -1,6 +1,6 @@
 ## 使用 `Drop` Trait 运行清理代码
 
-> [ch15-03-drop.md](https://github.com/rust-lang/book/blob/master/src/ch15-03-drop.md) <br>
+> [ch15-03-drop.md](https://github.com/rust-lang/book/blob/main/src/ch15-03-drop.md) <br>
 > commit 57adb83f69a69e20862d9e107b2a8bab95169b4c
 
 对于智能指针模式来说第二个重要的 trait 是 `Drop`，其允许我们在值要离开作用域时执行一些代码。可以为任何类型提供 `Drop` trait 的实现，同时所指定的代码被用于释放类似于文件或网络连接的资源。我们在智能指针上下文中讨论 `Drop` 是因为其功能几乎总是用于实现智能指针。例如，`Box<T>` 自定义了 `Drop` 用来释放 box 所指向的堆空间。

--- a/src/ch15-04-rc.md
+++ b/src/ch15-04-rc.md
@@ -1,6 +1,6 @@
 ## `Rc<T>` 引用计数智能指针
 
-> [ch15-04-rc.md](https://github.com/rust-lang/book/blob/master/src/ch15-04-rc.md) <br>
+> [ch15-04-rc.md](https://github.com/rust-lang/book/blob/main/src/ch15-04-rc.md) <br>
 > commit 6f292c8439927b4c5b870dd4afd2bfc52cc4eccc
 
 大部分情况下所有权是非常明确的：可以准确地知道哪个变量拥有某个值。然而，有些情况单个值可能会有多个所有者。例如，在图数据结构中，多个边可能指向相同的节点，而这个节点从概念上讲为所有指向它的边所拥有。节点直到没有任何边指向它之前都不应该被清理。

--- a/src/ch15-05-interior-mutability.md
+++ b/src/ch15-05-interior-mutability.md
@@ -1,6 +1,6 @@
 ## `RefCell<T>` 和内部可变性模式
 
-> [ch15-05-interior-mutability.md](https://github.com/rust-lang/book/blob/master/src/ch15-05-interior-mutability.md) <br>
+> [ch15-05-interior-mutability.md](https://github.com/rust-lang/book/blob/main/src/ch15-05-interior-mutability.md) <br>
 > commit 26565efc3f62d9dacb7c2c6d0f5974360e459493
 
 **内部可变性**（_Interior mutability_）是 Rust 中的一个设计模式，它允许你即使在有不可变引用时也可以改变数据，这通常是借用规则所不允许的。为了改变数据，该模式在数据结构中使用 `unsafe` 代码来模糊 Rust 通常的可变性和借用规则。我们还未讲到不安全代码；第十九章会学习它们。当可以确保代码在运行时会遵守借用规则，即使编译器不能保证的情况，可以选择使用那些运用内部可变性模式的类型。所涉及的 `unsafe` 代码将被封装进安全的 API 中，而外部类型仍然是不可变的。

--- a/src/ch15-06-reference-cycles.md
+++ b/src/ch15-06-reference-cycles.md
@@ -1,6 +1,6 @@
 ## 引用循环与内存泄漏
 
-> [ch15-06-reference-cycles.md](https://github.com/rust-lang/book/blob/master/src/ch15-06-reference-cycles.md) <br>
+> [ch15-06-reference-cycles.md](https://github.com/rust-lang/book/blob/main/src/ch15-06-reference-cycles.md) <br>
 > commit f617d58c1a88dd2912739a041fd4725d127bf9fb
 
 Rust 的内存安全性保证使其难以意外地制造永远也不会被清理的内存（被称为 **内存泄漏**（_memory leak_）），但并不是不可能。与在编译时拒绝数据竞争不同， Rust 并不保证完全地避免内存泄漏，这意味着内存泄漏在 Rust 被认为是内存安全的。这一点可以通过 `Rc<T>` 和 `RefCell<T>` 看出：创建引用循环的可能性是存在的。这会造成内存泄漏，因为每一项的引用计数永远也到不了 0，其值也永远不会被丢弃。

--- a/src/ch16-00-concurrency.md
+++ b/src/ch16-00-concurrency.md
@@ -1,6 +1,6 @@
 # 无畏并发
 
-> [ch16-00-concurrency.md](https://github.com/rust-lang/book/blob/master/src/ch16-00-concurrency.md) <br>
+> [ch16-00-concurrency.md](https://github.com/rust-lang/book/blob/main/src/ch16-00-concurrency.md) <br>
 > commit 1fedfc4b96c2017f64ecfcf41a0a07e2e815f24f
 
 安全且高效的处理并发编程是 Rust 的另一个主要目标。**并发编程**（_Concurrent programming_），代表程序的不同部分相互独立的执行，而 **并行编程**（_parallel programming_）代表程序不同部分于同时执行，这两个概念随着计算机越来越多的利用多处理器的优势时显得愈发重要。由于历史原因，在此类上下文中编程一直是困难且容易出错的：Rust 希望能改变这一点。

--- a/src/ch16-01-threads.md
+++ b/src/ch16-01-threads.md
@@ -1,6 +1,6 @@
 ## 使用线程同时运行代码
 
-> [ch16-01-threads.md](https://github.com/rust-lang/book/blob/master/src/ch16-01-threads.md) <br>
+> [ch16-01-threads.md](https://github.com/rust-lang/book/blob/main/src/ch16-01-threads.md) <br>
 > commit 1fedfc4b96c2017f64ecfcf41a0a07e2e815f24f
 
 在大部分现代操作系统中，已执行程序的代码在一个 **进程**（_process_）中运行，操作系统则负责管理多个进程。在程序内部，也可以拥有多个同时运行的独立部分。运行这些独立部分的功能被称为 **线程**（_threads_）。

--- a/src/ch16-02-message-passing.md
+++ b/src/ch16-02-message-passing.md
@@ -1,6 +1,6 @@
 ## 使用消息传递在线程间传送数据
 
-> [ch16-02-message-passing.md](https://github.com/rust-lang/book/blob/master/src/ch16-02-message-passing.md) <br>
+> [ch16-02-message-passing.md](https://github.com/rust-lang/book/blob/main/src/ch16-02-message-passing.md) <br>
 > commit 26565efc3f62d9dacb7c2c6d0f5974360e459493
 
 一个日益流行的确保安全并发的方式是 **消息传递**（_message passing_），这里线程或 actor 通过发送包含数据的消息来相互沟通。这个思想来源于 [Go 编程语言文档中](http://golang.org/doc/effective_go.html) 的口号：“不要通过共享内存来通讯；而是通过通讯来共享内存。”（“Do not communicate by sharing memory; instead, share memory by communicating.”）

--- a/src/ch16-03-shared-state.md
+++ b/src/ch16-03-shared-state.md
@@ -1,6 +1,6 @@
 ## 共享状态并发
 
-> [ch16-03-shared-state.md](https://github.com/rust-lang/book/blob/master/src/ch16-03-shared-state.md) <br>
+> [ch16-03-shared-state.md](https://github.com/rust-lang/book/blob/main/src/ch16-03-shared-state.md) <br>
 > commit ef072458f903775e91ea9e21356154bc57ee31da
 
 虽然消息传递是一个很好的处理并发的方式，但并不是唯一一个。再一次思考一下 Go 编程语言文档中口号的这一部分：“不要通过共享内存来通讯”（“do not communicate by sharing memory.”）：

--- a/src/ch16-04-extensible-concurrency-sync-and-send.md
+++ b/src/ch16-04-extensible-concurrency-sync-and-send.md
@@ -1,6 +1,6 @@
 ## 使用 `Sync` 和 `Send` trait 的可扩展并发
 
-> [ch16-04-extensible-concurrency-sync-and-send.md](https://github.com/rust-lang/book/blob/master/src/ch16-04-extensible-concurrency-sync-and-send.md) <br>
+> [ch16-04-extensible-concurrency-sync-and-send.md](https://github.com/rust-lang/book/blob/main/src/ch16-04-extensible-concurrency-sync-and-send.md) <br>
 > commit 426f3e4ec17e539ae9905ba559411169d303a031
 
 Rust 的并发模型中一个有趣的方面是：语言本身对并发知之 **甚少**。我们之前讨论的几乎所有内容，都属于标准库，而不是语言本身的内容。由于不需要语言提供并发相关的基础设施，并发方案不受标准库或语言所限：我们可以编写自己的或使用别人编写的并发功能。

--- a/src/ch17-00-oop.md
+++ b/src/ch17-00-oop.md
@@ -1,6 +1,6 @@
 # Rust 的面向对象特性
 
-> [ch17-00-oop.md](https://github.com/rust-lang/book/blob/master/src/ch17-00-oop.md)
+> [ch17-00-oop.md](https://github.com/rust-lang/book/blob/main/src/ch17-00-oop.md)
 > <br>
 > commit 1fedfc4b96c2017f64ecfcf41a0a07e2e815f24f
 

--- a/src/ch17-01-what-is-oo.md
+++ b/src/ch17-01-what-is-oo.md
@@ -1,6 +1,6 @@
 ## 面向对象语言的特征
 
-> [ch17-01-what-is-oo.md](https://github.com/rust-lang/book/blob/master/src/ch17-01-what-is-oo.md)
+> [ch17-01-what-is-oo.md](https://github.com/rust-lang/book/blob/main/src/ch17-01-what-is-oo.md)
 > <br>
 > commit 34caca254c3e08ff9fe3ad985007f45e92577c03
 

--- a/src/ch17-02-trait-objects.md
+++ b/src/ch17-02-trait-objects.md
@@ -1,6 +1,6 @@
 ## 为使用不同类型的值而设计的 trait 对象
 
-> [ch17-02-trait-objects.md](https://github.com/rust-lang/book/blob/master/src/ch17-02-trait-objects.md)
+> [ch17-02-trait-objects.md](https://github.com/rust-lang/book/blob/main/src/ch17-02-trait-objects.md)
 > <br>
 > commit 7b23a000fc511d985069601eb5b09c6017e609eb
 

--- a/src/ch17-03-oo-design-patterns.md
+++ b/src/ch17-03-oo-design-patterns.md
@@ -1,6 +1,6 @@
 ## 面向对象设计模式的实现
 
-> [ch17-03-oo-design-patterns.md](https://github.com/rust-lang/book/blob/master/src/ch17-03-oo-design-patterns.md)
+> [ch17-03-oo-design-patterns.md](https://github.com/rust-lang/book/blob/main/src/ch17-03-oo-design-patterns.md)
 > <br>
 > commit 7e219336581c41a80fd41f4fbe615fecb6ed0a7d
 

--- a/src/ch18-00-patterns.md
+++ b/src/ch18-00-patterns.md
@@ -1,6 +1,6 @@
 # 模式用来匹配值的结构
 
-> [ch18-00-patterns.md](https://github.com/rust-lang/book/blob/master/src/ch18-00-patterns.md)
+> [ch18-00-patterns.md](https://github.com/rust-lang/book/blob/main/src/ch18-00-patterns.md)
 > <br>
 > commit 1fedfc4b96c2017f64ecfcf41a0a07e2e815f24f
 

--- a/src/ch18-01-all-the-places-for-patterns.md
+++ b/src/ch18-01-all-the-places-for-patterns.md
@@ -1,6 +1,6 @@
 ## 所有可能会用到模式的位置
 
-> [ch18-01-all-the-places-for-patterns.md](https://github.com/rust-lang/book/blob/master/src/ch18-01-all-the-places-for-patterns.md)
+> [ch18-01-all-the-places-for-patterns.md](https://github.com/rust-lang/book/blob/main/src/ch18-01-all-the-places-for-patterns.md)
 > <br>
 > commit 426f3e4ec17e539ae9905ba559411169d303a031
 

--- a/src/ch18-02-refutability.md
+++ b/src/ch18-02-refutability.md
@@ -1,6 +1,6 @@
 ## Refutability（可反驳性）: 模式是否会匹配失效
 
-> [ch18-02-refutability.md](https://github.com/rust-lang/book/blob/master/src/ch18-02-refutability.md)
+> [ch18-02-refutability.md](https://github.com/rust-lang/book/blob/main/src/ch18-02-refutability.md)
 > <br>
 > commit 30fe5484f3923617410032d28e86a5afdf4076fb
 

--- a/src/ch18-03-pattern-syntax.md
+++ b/src/ch18-03-pattern-syntax.md
@@ -1,6 +1,6 @@
 ## 所有的模式语法
 
-> [ch18-03-pattern-syntax.md](https://github.com/rust-lang/book/blob/master/src/ch18-03-pattern-syntax.md)
+> [ch18-03-pattern-syntax.md](https://github.com/rust-lang/book/blob/main/src/ch18-03-pattern-syntax.md)
 > <br>
 > commit 86f0ae4831f24b3c429fa4845b900b4cad903a8b
 

--- a/src/ch19-00-advanced-features.md
+++ b/src/ch19-00-advanced-features.md
@@ -1,6 +1,6 @@
 # 高级特征
 
-> [ch19-00-advanced-features.md](https://github.com/rust-lang/book/blob/master/src/ch19-00-advanced-features.md)
+> [ch19-00-advanced-features.md](https://github.com/rust-lang/book/blob/main/src/ch19-00-advanced-features.md)
 > <br>
 > commit 10f89936b02dc366a2d0b34083b97cadda9e0ce4
 

--- a/src/ch19-01-unsafe-rust.md
+++ b/src/ch19-01-unsafe-rust.md
@@ -1,6 +1,6 @@
 ## 不安全 Rust
 
-> [ch19-01-unsafe-rust.md](https://github.com/rust-lang/book/blob/master/src/ch19-01-unsafe-rust.md)
+> [ch19-01-unsafe-rust.md](https://github.com/rust-lang/book/blob/main/src/ch19-01-unsafe-rust.md)
 > <br>
 > commit 28fa3d15b0bc67ea5e79eeff2198e4277fc61baf
 

--- a/src/ch19-03-advanced-traits.md
+++ b/src/ch19-03-advanced-traits.md
@@ -1,6 +1,6 @@
 ## 高级 trait
 
-> [ch19-03-advanced-traits.md](https://github.com/rust-lang/book/blob/master/src/ch19-03-advanced-traits.md)
+> [ch19-03-advanced-traits.md](https://github.com/rust-lang/book/blob/main/src/ch19-03-advanced-traits.md)
 > <br>
 > commit 426f3e4ec17e539ae9905ba559411169d303a031
 

--- a/src/ch19-04-advanced-types.md
+++ b/src/ch19-04-advanced-types.md
@@ -1,6 +1,6 @@
 ## 高级类型
 
-> [ch19-04-advanced-types.md](https://github.com/rust-lang/book/blob/master/src/ch19-04-advanced-types.md)
+> [ch19-04-advanced-types.md](https://github.com/rust-lang/book/blob/main/src/ch19-04-advanced-types.md)
 > <br>
 > commit 426f3e4ec17e539ae9905ba559411169d303a031
 

--- a/src/ch19-05-advanced-functions-and-closures.md
+++ b/src/ch19-05-advanced-functions-and-closures.md
@@ -1,6 +1,6 @@
 ## 高级函数与闭包
 
-> [ch19-05-advanced-functions-and-closures.md](https://github.com/rust-lang/book/blob/master/src/ch19-05-advanced-functions-and-closures.md)
+> [ch19-05-advanced-functions-and-closures.md](https://github.com/rust-lang/book/blob/main/src/ch19-05-advanced-functions-and-closures.md)
 > <br>
 > commit 426f3e4ec17e539ae9905ba559411169d303a031
 

--- a/src/ch19-06-macros.md
+++ b/src/ch19-06-macros.md
@@ -1,6 +1,6 @@
 ## 宏
 
-> [ch19-06-macros.md](https://github.com/rust-lang/book/blob/master/src/ch19-06-macros.md)
+> [ch19-06-macros.md](https://github.com/rust-lang/book/blob/main/src/ch19-06-macros.md)
 > <br>
 > commit 7ddc46460f09a5cd9bd2a620565bdc20b3315ea9
 

--- a/src/ch20-00-final-project-a-web-server.md
+++ b/src/ch20-00-final-project-a-web-server.md
@@ -1,6 +1,6 @@
 # 最后的项目: 构建多线程 web server
 
-> [ch20-00-final-project-a-web-server.md](https://github.com/rust-lang/book/blob/master/src/ch20-00-final-project-a-web-server.md)
+> [ch20-00-final-project-a-web-server.md](https://github.com/rust-lang/book/blob/main/src/ch20-00-final-project-a-web-server.md)
 > <br>
 > commit c084bdd9ee328e7e774df19882ccc139532e53d8
 

--- a/src/ch20-01-single-threaded.md
+++ b/src/ch20-01-single-threaded.md
@@ -1,6 +1,6 @@
 ## 构建单线程 web server
 
-> [ch20-01-single-threaded.md](https://github.com/rust-lang/book/blob/master/src/ch20-01-single-threaded.md)
+> [ch20-01-single-threaded.md](https://github.com/rust-lang/book/blob/main/src/ch20-01-single-threaded.md)
 > <br>
 > commit f617d58c1a88dd2912739a041fd4725d127bf9fb
 

--- a/src/ch20-02-multithreaded.md
+++ b/src/ch20-02-multithreaded.md
@@ -1,6 +1,6 @@
 ## 将单线程 server 变为多线程 server
 
-> [ch20-02-multithreaded.md](https://github.com/rust-lang/book/blob/master/src/ch20-02-multithreaded.md)
+> [ch20-02-multithreaded.md](https://github.com/rust-lang/book/blob/main/src/ch20-02-multithreaded.md)
 > <br>
 > commit 120e76a0cc77c9cde52643f847ed777f8f441817
 

--- a/src/ch20-02-slow-requests.md
+++ b/src/ch20-02-slow-requests.md
@@ -1,6 +1,6 @@
 ## 慢请求如何影响吞吐率
 
-> [ch20-02-slow-requests.md](https://github.com/rust-lang/book/blob/master/second-edition/src/ch20-02-slow-requests.md)
+> [ch20-02-slow-requests.md](https://github.com/rust-lang/book/blob/main/second-edition/src/ch20-02-slow-requests.md)
 > <br>
 > commit d06a6a181fd61704cbf7feb55bc61d518c6469f9
 

--- a/src/ch20-03-designing-the-interface.md
+++ b/src/ch20-03-designing-the-interface.md
@@ -1,6 +1,6 @@
 ## 设计线程池接口
 
-> [ch20-03-designing-the-interface.md](https://github.com/rust-lang/book/blob/master/second-edition/src/ch20-03-designing-the-interface.md)
+> [ch20-03-designing-the-interface.md](https://github.com/rust-lang/book/blob/main/second-edition/src/ch20-03-designing-the-interface.md)
 > <br>
 > commit d06a6a181fd61704cbf7feb55bc61d518c6469f9
 

--- a/src/ch20-03-graceful-shutdown-and-cleanup.md
+++ b/src/ch20-03-graceful-shutdown-and-cleanup.md
@@ -1,6 +1,6 @@
 ## 优雅停机与清理
 
-> [ch20-03-graceful-shutdown-and-cleanup.md](https://github.com/rust-lang/book/blob/master/src/ch20-03-graceful-shutdown-and-cleanup.md)
+> [ch20-03-graceful-shutdown-and-cleanup.md](https://github.com/rust-lang/book/blob/main/src/ch20-03-graceful-shutdown-and-cleanup.md)
 > <br>
 > commit 9a5a1bfaec3b7763e1bcfd31a2fb19fe95183746
 

--- a/src/foreword.md
+++ b/src/foreword.md
@@ -1,6 +1,6 @@
 # 前言
 
-> [foreword.md](https://github.com/rust-lang/book/blob/master/src/foreword.md)
+> [foreword.md](https://github.com/rust-lang/book/blob/main/src/foreword.md)
 > <br>
 > commit 1fedfc4b96c2017f64ecfcf41a0a07e2e815f24f
 

--- a/src/title-page.md
+++ b/src/title-page.md
@@ -1,6 +1,6 @@
 # Rust 程序设计语言
 
-> [title-page.md](https://github.com/rust-lang/book/blob/master/src/title-page.md) <br>
+> [title-page.md](https://github.com/rust-lang/book/blob/main/src/title-page.md) <br>
 > commit a2bd349f8654f5c45ad1f07394225f946954b8ef
 
 **Steve Klabnik 和 Carol Nichols，以及来自 Rust 社区的贡献（Rust 中文社区翻译）**


### PR DESCRIPTION
将文章开头的原文引用信息中的链接全部更新，如：
更新前：https://github.com/rust-lang/book/blob/master/src/***.md
更新后：https://github.com/rust-lang/book/blob/main/src/***.md