### PR TITLE
docs: remove unsafe Ferris designations from code

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,8 @@ jobs:
         mdbook --version
     - name: Run mdBook Build
       run: mdbook build
-    - name: Deploy gh-pages 
+    - name: Deploy gh-pages
+      if: ${{ github.ref == 'refs/heads/main' }}
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -56,4 +56,4 @@ vuepress dev ./src
 本翻译加速查看站点有：
  - 深圳站点：<http://120.78.128.153/rustbook>
 
-[GitBook.com](https://www.gitbook.com/) 地址：<https://legacy.gitbook.com/book/kaisery/trpl-zh-cn/details>
+[GitBook.com](https://www.gitbook.com/) 地址：<https://kaisery.github.io/trpl-zh-cn/>

--- a/ferris.js
+++ b/ferris.js
@@ -1,51 +1,47 @@
 var ferrisTypes = [
-    {
-      attr: 'does_not_compile',
-      title: '这些代码不能编译！'
-    },
-    {
-      attr: 'panics',
-      title: '这些代码会 panic！'
-    },
-    {
-      attr: 'unsafe',
-      title: '这些代码块包含不安全（unsafe）代码。'
-    },
-    {
-      attr: 'not_desired_behavior',
-      title: '这些代码不会产生期望的行为。'
-    }
-  ]
-  
-  document.addEventListener('DOMContentLoaded', () => {
-    for (var ferrisType of ferrisTypes) {
-      attachFerrises(ferrisType)
-    }
-  })
-  
-  function attachFerrises (type) {
-    var elements = document.getElementsByClassName(type.attr)
-  
-    for (var codeBlock of elements) {
-      var lines = codeBlock.textContent.split(/\r|\r\n|\n/).length - 1;
-  
-      if (lines >= 4) {
-        attachFerris(codeBlock, type)
-      }
+  {
+    attr: 'does_not_compile',
+    title: '这些代码不能编译！'
+  },
+  {
+    attr: 'panics',
+    title: '这些代码会 panic！'
+  },
+  {
+    attr: 'not_desired_behavior',
+    title: '这些代码不会产生期望的行为。'
+  }
+]
+
+document.addEventListener('DOMContentLoaded', () => {
+  for (var ferrisType of ferrisTypes) {
+    attachFerrises(ferrisType)
+  }
+})
+
+function attachFerrises (type) {
+  var elements = document.getElementsByClassName(type.attr)
+
+  for (var codeBlock of elements) {
+    var lines = codeBlock.textContent.split(/\r|\r\n|\n/).length - 1;
+
+    if (lines >= 4) {
+      attachFerris(codeBlock, type)
     }
   }
-  
-  function attachFerris (element, type) {
-    var a = document.createElement('a')
-    a.setAttribute('href', 'ch00-00-introduction.html#ferris')
-    a.setAttribute('target', '_blank')
-  
-    var img = document.createElement('img')
-    img.setAttribute('src', 'img/ferris/' + type.attr + '.svg')
-    img.setAttribute('title', type.title)
-    img.className = 'ferris'
-  
-    a.appendChild(img)
-  
-    element.parentElement.insertBefore(a, element)
-  }
+}
+
+function attachFerris (element, type) {
+  var a = document.createElement('a')
+  a.setAttribute('href', 'ch00-00-introduction.html#ferris')
+  a.setAttribute('target', '_blank')
+
+  var img = document.createElement('img')
+  img.setAttribute('src', 'img/ferris/' + type.attr + '.svg')
+  img.setAttribute('title', type.title)
+  img.className = 'ferris'
+
+  a.appendChild(img)
+
+  element.parentElement.insertBefore(a, element)
+}


### PR DESCRIPTION
虽然 https://doc.rust-lang.org/book/ 还没更新，但是 Unsafe Ferris 已从官方源码中删除，具体见此 [PR](https://github.com/rust-lang/book/issues/2555)