### PR TITLE
Fix typo and improve grammar

### DIFF
--- a/src/ch08-03-hash-maps.md
+++ b/src/ch08-03-hash-maps.md
@@ -42,7 +42,7 @@ let scores: HashMap<_, _> = teams.iter().zip(initial_scores.iter()).collect();
 
 <span class="caption">示例 8-21：用队伍列表和分数列表创建哈希 map</span>
 
-这里 `HashMap<_, _>` 类型注解是必要的，因为可能 `collect` 很多不同的数据结构，而除非显式指定否则 Rust 无从得知你需要的类型。但是对于键和值的类型参数来说，可以使用下划线占位，而 Rust 能够根据 vector 中数据的类型推断出 `HashMap` 所包含的类型。
+这里 `HashMap<_, _>` 类型注解是必要的，因为可能 `collect` 为很多不同的数据结构，而除非显式指定否则 Rust 无从得知你需要的类型。但是对于键和值的类型参数来说，可以使用下划线占位，而 Rust 能够根据 vector 中数据的类型推断出 `HashMap` 所包含的类型。
 
 ### 哈希 map 和所有权
 
@@ -186,7 +186,7 @@ println!("{:?}", map);
 
 vector、字符串和哈希 map 会在你的程序需要储存、访问和修改数据时帮助你。这里有一些你应该能够解决的练习问题：
 
-* 给定一系列数字，使用 vector 并返回这个列表的平均数（mean, average）、中位数（排列数组后位于中间的值）和众数（mode，出现次数最多的值；这里哈希函数会很有帮助）。
+* 给定一系列数字，使用 vector 并返回这个列表的平均数（mean, average）、中位数（排列数组后位于中间的值）和众数（mode，出现次数最多的值；这里哈希 map 会很有帮助）。
 * 将字符串转换为 Pig Latin，也就是每一个单词的第一个辅音字母被移动到单词的结尾并增加 “ay”，所以 “first” 会变成 “irst-fay”。元音字母开头的单词则在结尾增加  “hay”（“apple” 会变成 “apple-hay”）。牢记 UTF-8 编码！
 * 使用哈希 map 和 vector，创建一个文本接口来允许用户向公司的部门中增加员工的名字。例如，“Add Sally to Engineering” 或 “Add Amir to Sales”。接着让用户获取一个部门的所有员工的列表，或者公司每个部门的所有员工按照字典序排列的列表。
 


### PR DESCRIPTION
## Improve grammar

原文:
> The type annotation `HashMap<_, _>` is needed here because it’s possible to `collect` **into** many different data structures and Rust doesn’t know which you want unless you specify.

（补充翻译 "into" 为 “为”，消除歧义）

## Fix typo

原文：
> a hash map will be helpful here

（将 “哈希函数” 更正为 “哈希 map”）