### PR TITLE
Improve translation grammar

### DIFF
--- a/src/ch09-02-recoverable-errors-with-result.md
+++ b/src/ch09-02-recoverable-errors-with-result.md
@@ -180,7 +180,7 @@ fn main() {
 }
 ```
 
-`expect` 与 `unwrap` 的使用方式一样：返回文件句柄或调用 `panic!` 宏。`expect` 在调用 `panic!` 时使用的错误信息将是我们传递给 `expect` 的参数，而不像`unwrap` 那样使用默认的 `panic!` 信息。它看起来像这样：
+`expect` 与 `unwrap` 的使用方式一样：返回文件句柄或调用 `panic!` 宏。`expect` 在调用 `panic!` 时使用的错误信息将是我们传递给 `expect` 的参数，而不像 `unwrap` 那样使用默认的 `panic!` 信息。它看起来像这样：
 
 ```text
 thread 'main' panicked at 'Failed to open hello.txt: Error { repr: Os { code:

--- a/src/ch09-02-recoverable-errors-with-result.md
+++ b/src/ch09-02-recoverable-errors-with-result.md
@@ -180,7 +180,7 @@ fn main() {
 }
 ```
 
-`expect` 与 `unwrap` 的使用方式一样：返回文件句柄或调用 `panic!` 宏。`expect` 用来调用 `panic!` 的错误信息将会作为参数传递给 `expect` ，而不像`unwrap` 那样使用默认的 `panic!` 信息。它看起来像这样：
+`expect` 与 `unwrap` 的使用方式一样：返回文件句柄或调用 `panic!` 宏。`expect` 在调用 `panic!` 时使用的错误信息将是我们传递给 `expect` 的参数，而不像`unwrap` 那样使用默认的 `panic!` 信息。它看起来像这样：
 
 ```text
 thread 'main' panicked at 'Failed to open hello.txt: Error { repr: Os { code:


### PR DESCRIPTION
原文：
> The error message used by `expect` in its call to `panic!` will be the parameter that we pass to `expect`, rather than the default `panic!` message that `unwrap` uses.

（改进译文语法，使其更准确清晰）