### PR TITLE
修复示例代码中的`HTTP/1.x`格式错误

### DIFF
--- a/src/ch20-01-single-threaded.md
+++ b/src/ch20-01-single-threaded.md
@@ -371,9 +371,9 @@ fn handle_connection(mut stream: TcpStream) {
     // --snip--
 
     let (status_line, filename) = if buffer.starts_with(get) {
-        ("HTTP/1.1 200 OK\r\n\r\n", "hello.html")
+        ("HTTP/1.1 200 OK", "hello.html")
     } else {
-        ("HTTP/1.1 404 NOT FOUND\r\n\r\n", "404.html")
+        ("HTTP/1.1 404 NOT FOUND", "404.html")
     };
 
     let contents = fs::read_to_string(filename).unwrap();


### PR DESCRIPTION
正确的`HTTP/1.x`消息的格式如下（图片引用自[MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Messages)）：
![image](https://user-images.githubusercontent.com/15844309/140852036-21a017a7-4c7d-42b3-acfc-44cfc94221ae.png)

对于响应消息：

1. 首行用于描述请求的执行状态，即示例代码中的`HTTP/1.1 200 OK`/`HTTP/1.1 404 NOT FOUND`
2. 随后是可选的`HTTP Header`s（每行表示一个`HTTP Header`），其与首行之间`没有空行`
3. 在`HTTP Header`s之后，使用一个`空行`（即`\r\n\r\n`）表示HTTP元数据已发送完毕
4. 最后则是可选的`HTTP body`

在示例代码中，`status_line`用于描述请求的执行状态，后续的`CRLF`是通过[`format`](https://github.com/KaiserY/trpl-zh-cn/blob/70a197b5d8acd4bd69523ede31cb952873e6f460/src/ch20-01-single-threaded.md?plain=1#L381-L385)宏插入的，`status_line`中的两个`CRLF`应该删除。

