### PR TITLE
fix: response with correct HTTP/1.x Message format

### DIFF
--- a/src/ch20-02-multithreaded.md
+++ b/src/ch20-02-multithreaded.md
@@ -21,7 +21,7 @@ use std::time::Duration;
 // --snip--
 
 fn handle_connection(mut stream: TcpStream) {
-#     let mut buffer = [0; 512];
+#     let mut buffer = [0; 1024];
 #     stream.read(&mut buffer).unwrap();
     // --snip--
 
@@ -29,12 +29,12 @@ fn handle_connection(mut stream: TcpStream) {
     let sleep = b"GET /sleep HTTP/1.1\r\n";
 
     let (status_line, filename) = if buffer.starts_with(get) {
-        ("HTTP/1.1 200 OK\r\n\r\n", "hello.html")
+        ("HTTP/1.1 200 OK", "hello.html")
     } else if buffer.starts_with(sleep) {
         thread::sleep(Duration::from_secs(5));
-        ("HTTP/1.1 200 OK\r\n\r\n", "hello.html")
+        ("HTTP/1.1 200 OK", "hello.html")
     } else {
-        ("HTTP/1.1 404 NOT FOUND\r\n\r\n", "404.html")
+        ("HTTP/1.1 404 NOT FOUND", "404.html")
     };
 
     // --snip--


### PR DESCRIPTION
The correct `HTTP/1.x Message`'s headers are followed after the `start-line` which describing the requests to be implemented. After the `headers` is a `blank line` indicating all `meta-information` for the request has been sent. Then the `optional body` is followed. (Reference: #560)
Increase HTTP buffer size to 1024(keep the same with the buffer size in `ch20-01-single-threaded.md`).
