### PR TITLE
fix ch02-00

### DIFF
--- a/src/ch02-00-guessing-game-tutorial.md
+++ b/src/ch02-00-guessing-game-tutorial.md
@@ -62,7 +62,7 @@ $ cd guessing_game
 {{#rustdoc_include ../listings/ch02-guessing-game-tutorial/listing-02-01/src/main.rs:io}}
 ```
 
-默认情况下，Rust 将 [_prelude_][prelude]<!-- ignore --> 模块中少量的类型引入到每个程序的作用域中。如果需要的类型不在 prelude 中，你必须使用 `use` 语句显式地将其引入作用域。`std::io` 库提供很多有用的功能，包括接收用户输入的功能。
+默认情况下，Rust 将 [_prelude_][prelude]<!-- ignore --> 模块中少量的类型引入到每个程序的作用域中。
 
 如果你需要的类型不在 prelude 中，你必须使用 `use` 语句显式地将其引入作用域。`std::io` 库提供很多有用的功能，包括接收用户输入的功能。
 


### PR DESCRIPTION
删除 [`ch02-00`](https://github.com/KaiserY/trpl-zh-cn/blob/main/src/ch02-00-guessing-game-tutorial.md) 段落 [`处理一次猜测`](https://github.com/KaiserY/trpl-zh-cn/blob/main/src/ch02-00-guessing-game-tutorial.md#%E5%A4%84%E7%90%86%E4%B8%80%E6%AC%A1%E7%8C%9C%E6%B5%8B) 中一处重复的内容。