### PR TITLE
Fix setting env problem

### DIFF
--- a/src/ch12-05-working-with-environment-variables.md
+++ b/src/ch12-05-working-with-environment-variables.md
@@ -97,7 +97,7 @@ PS> $Env:CASE_INSENSITIVE=1; cargo run to poem.txt
 这回应该得到包含可能有大写字母的 “to” 的行：
 
 ```console
-$ CASE_INSENSITIVE=1 cargo run to poem.txt
+$ (CASE_INSENSITIVE=1; cargo run to poem.txt)
     Finished dev [unoptimized + debuginfo] target(s) in 0.0s
      Running `target/debug/minigrep to poem.txt`
 Are you nobody, too?


### PR DESCRIPTION
修复 ch12-05 中设置环境变量命令中的错误

`CASE_INSENSITIVE=1 cargo run to poem.txt` 无法有效设置环境变量，需要修改为 `(CASE_INSENSITIVE=1; cargo run to poem.txt)`

可以通过下面方式快速对比两种方式的区别：

```shell
CASE_INSENSITIVE=1 echo $CASE_INSENSITIVE
```

```shell
(CASE_INSENSITIVE=1; echo $CASE_INSENSITIVE)
```

第一个命令返回空，第二个命令返回"1"（运行环境：MacOS Terminal）

具体解释可以参考：[这个回答](https://unix.stackexchange.com/a/56454)