### PR TITLE
fix(docs):修复ch13-03 html元素结束标签缺失的问题

### DIFF
--- a/src/ch13-03-improving-our-io-project.md
+++ b/src/ch13-03-improving-our-io-project.md
@@ -56,7 +56,7 @@
 {{#rustdoc_include ../listings/ch13-functional-features/listing-13-26/src/lib.rs:here}}
 ```
 
-<span class="caption">示例 13-26：以迭代器作为参数更新 `Config::new` 的签名
+<span class="caption">示例 13-26：以迭代器作为参数更新 `Config::new` 的签名</span>
 
 `env::args` 函数的标准库文档显示，它返回的迭代器的类型为 `std::env::Args`。我们已经更新了 `Config :: new` 函数的签名，因此参数 `args` 的类型为 `std::env::Args` 而不是 `&[String]`。因为我们拥有 `args` 的所有权，并且将通过对其进行迭代来改变 `args` ，所以我们可以将 `mut` 关键字添加到 `args` 参数的规范中以使其可变。
 


### PR DESCRIPTION
## 文章ch13-03-improving-our-io-project 59行span元素缺失结束标签导致vuepress build的时候报错： 

Compiling with vite[vite:vue] Element is missing end tag. 
Compiling with vite - failed in 3.10s
SyntaxError: Element is missing end tag.

![20220920234325](https://user-images.githubusercontent.com/18044206/191303893-bbf47983-c8f7-43e3-b2b2-e555ad9977b4.png)

## 环境
node: v16.15.1
platform: win10
vuepress: ^2.0.0-beta.51