### PR TITLE
Update ch07-04-bringing-paths-into-scope-with-the-use-keyword.md

### DIFF
--- a/src/ch07-04-bringing-paths-into-scope-with-the-use-keyword.md
+++ b/src/ch07-04-bringing-paths-into-scope-with-the-use-keyword.md
@@ -34,7 +34,7 @@
 {{#include ../listings/ch07-managing-growing-projects/listing-07-12/output.txt}}
 ```
 
-注意这里还有一个警告说 `use` 在其作用域内不再被使用！为了修复这个问题，也将 `use` 移动到 `customer` 模块内，或者在父模块通过 `customer` 模块内的 `super::front_of_house::hosting`（原文 `super::hosting`？）引用这个短路径。
+注意这里还有一个警告说 `use` 在其作用域内不再被使用！为了修复这个问题，可以将 `use` 移动到 `customer` 模块内，或者在子模块 `customer` 内通过 `super::hosting` 引用父模块中的这个短路径。
 
 ### 创建惯用的 `use` 路径
 


### PR DESCRIPTION
这里原文应该是没问题的，因为这个问题的第二种修复方法是指在父模块的 `use` 保留的情况下，在子模块内引用父模块中的这个短路径。