### PR TITLE
fix 7.5换行

### DIFF
--- a/src/ch07-05-separating-modules-into-different-files.md
+++ b/src/ch07-05-separating-modules-into-different-files.md
@@ -59,6 +59,7 @@
 >
 > * *src/front_of_house.rs*（我们所介绍的）
 > * *src/front_of_house/mod.rs*（老风格，不过仍然支持）
+>
 > 对于 `front_of_house` 的子模块 `hosting`，编译器会在如下位置查找模块代码：
 >
 > * *src/front_of_house/hosting.rs*（我们所介绍的）


### PR DESCRIPTION
7.5 “另一种文件路径” 中间段落，少了个换行，导致排版错误。

原文源文件内容：
```

> ### Alternate File Paths
>
> So far we’ve covered the most idiomatic file paths the Rust compiler uses,
> but Rust also supports an older style of file path. For a module named
> `front_of_house` declared in the crate root, the compiler will look for the
> module’s code in:
>
> * *src/front_of_house.rs* (what we covered)
> * *src/front_of_house/mod.rs* (older style, still supported path)
>
> For a module named `hosting` that is a submodule of `front_of_house`, the
> compiler will look for the module’s code in:
>
> * *src/front_of_house/hosting.rs* (what we covered)
> * *src/front_of_house/hosting/mod.rs* (older style, still supported path)
>
> If you use both styles for the same module, you’ll get a compiler error. Using
> a mix of both styles for different modules in the same project is allowed, but
> might be confusing for people navigating your project.
>
> The main downside to the style that uses files named *mod.rs* is that your
> project can end up with many files named *mod.rs*, which can get confusing
> when you have them open in your editor at the same time.
```