### PR TITLE
fix: typo

### DIFF
--- a/src/ch04-01-what-is-ownership.md
+++ b/src/ch04-01-what-is-ownership.md
@@ -183,7 +183,7 @@ access the heap data." src="img/trpl04-04.svg" class="center" style="width:
 
 这样就解决了我们的问题！因为只有 `s2` 是有效的，当其离开作用域，它就释放自己的内存，完毕。
 
-另外，这里还隐含了一个设计选择：Rust 永远也不会自动创建数据的 “深拷贝”。因此，任何 **自动** 的复制可以被认为对运行时性能影响较小。
+另外，这里还隐含了一个设计选择：Rust 永远也不会自动创建数据的 “深拷贝”。因此，任何 **自动** 的复制都可以被认为是对运行时性能影响较小的。
 
 <a id="ways-variables-and-data-interact-clone"></a>
 


### PR DESCRIPTION
原文:Therefore, any automatic copying can be assumed to be inexpensive in terms of runtime performance.