### PR TITLE
Update ch20-05-macros.md

### DIFF
--- a/src/ch20-05-macros.md
+++ b/src/ch20-05-macros.md
@@ -237,7 +237,7 @@ DeriveInput {
 
 ### 类属性宏
 
-类属性宏与自定义 `derive` 宏相似，不同之处在于它们不是为 `derive` 属性生成代码，而是允许你创建新的属性。它们也更为灵活；`derive` 只能用于结构体和枚举；属性还可以用于其它的项，比如函数。作为一个使用类属性宏的例子，可以创建一个名为 `route` 的属性用于注解 web 应用程序框架（web application framework）的函数：
+类属性（Attribute-Like）宏与自定义 `derive` 宏相似，不同之处在于它们不是为 `derive` 属性生成代码，而是允许你创建新的属性。它们也更为灵活；`derive` 只能用于结构体和枚举；属性还可以用于其它的项，比如函数。作为一个使用类属性宏的例子，可以创建一个名为 `route` 的属性用于注解 web 应用程序框架（web application framework）的函数：
 
 ```rust,ignore
 #[route(GET, "/")]


### PR DESCRIPTION
为「类属性宏」增加英文原文，与「类函数宏」的翻译格式保持一致。这确实有助于理解。
<img width="1088" alt="Clipboard_Screenshot_1750243515" src="https://github.com/user-attachments/assets/08546f8c-bf11-4eef-ac0b-900eb69bdfa4" />
