### PR TITLE
fix: 章节14.3：Correct cargo test command for workspace(lan: Chinece(中文简体))

### DIFF
--- a/src/ch14-03-cargo-workspaces.md
+++ b/src/ch14-03-cargo-workspaces.md
@@ -192,7 +192,7 @@ error[E0432]: unresolved import `rand`
 {{#rustdoc_include ../listings/ch14-more-about-cargo/no-listing-04-workspace-with-tests/add/add_one/src/lib.rs}}
 ```
 
-在顶级 *add* 目录运行 `cargo test`。在像这样的工作空间结构中运行 `cargo test` 会运行工作空间中所有 crate 的测试。：
+在顶级 *add* 目录运行 `cargo test --workspace`。在像这样的工作空间结构中运行 `cargo test --workspace` 会运行工作空间中所有 crate 的测试。：
 
 ```console
 $ cargo test


### PR DESCRIPTION
Updated the command to run tests in a Cargo workspace.(lan: Chinece(中文简体))